### PR TITLE
Generate random ball animations in Godot without binaries

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -1,3 +1,11 @@
 [gd_resource type="Resource" load_steps=2 format=3 uid="uid://project"]
 
 config_version = 4
+
+[application]
+config/name="SatisfyGen"
+run/main_scene="res://scenes/Main.tscn"
+
+[display]
+window/size/width=640
+window/size/height=480

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -8,3 +8,8 @@ script = ExtResource("res://scripts/Main.gd")
 wait_time = 0.5
 autostart = true
 one_shot = false
+
+[node name="ResetTimer" type="Timer" parent="."]
+wait_time = 12.0
+autostart = true
+one_shot = false

--- a/scenes/Ramp.tscn
+++ b/scenes/Ramp.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3]
+
+[node name="Ramp" type="StaticBody2D"]
+script = ExtResource("res://scripts/Ramp.gd")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = RectangleShape2D {
+    size = Vector2(100, 20)
+}

--- a/scenes/Wall.tscn
+++ b/scenes/Wall.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3]
+
+[node name="Wall" type="StaticBody2D"]
+script = ExtResource("res://scripts/Wall.gd")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = RectangleShape2D {
+    size = Vector2(20, 480)
+}

--- a/scripts/Ball.gd
+++ b/scripts/Ball.gd
@@ -1,4 +1,19 @@
 extends RigidBody2D
 
+# Rysowanie kulki i prosta logika zycia
+@onready var shape: CircleShape2D = $CollisionShape2D.shape
+
 func _ready():
-    pass
+    randomize()
+    connect("body_entered", _on_body_entered)
+    update()
+
+func _on_body_entered(body: Node) -> void:
+    pass  # brak dzwieku
+
+func _process(delta: float) -> void:
+    if position.y > 500:
+        queue_free()
+
+func _draw() -> void:
+    draw_circle(Vector2.ZERO, shape.radius, Color.WHITE)

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -1,12 +1,53 @@
 extends Node2D
 
+# Timery sterujace generowaniem kulek i resetem sceny
 @onready var spawn_timer = $SpawnTimer
+@onready var reset_timer = $ResetTimer
+
+# Sceny obiektow
 @export var ball_scene: PackedScene = preload("res://scenes/Ball.tscn")
+@export var ramp_scene: PackedScene = preload("res://scenes/Ramp.tscn")
+@export var wall_scene: PackedScene = preload("res://scenes/Wall.tscn")
 
 func _ready():
+    randomize()
     spawn_timer.timeout.connect(_on_spawn_timer_timeout)
+    reset_timer.timeout.connect(_on_reset_timer_timeout)
+    _generate_layout()
+    reset_timer.wait_time = randf_range(10.0, 15.0)
 
 func _on_spawn_timer_timeout():
     var ball = ball_scene.instantiate()
     ball.position = Vector2(randi() % 640, 0)
     add_child(ball)
+
+func _on_reset_timer_timeout():
+    _clear_layout()
+    _generate_layout()
+    reset_timer.wait_time = randf_range(10.0, 15.0)
+
+func _clear_layout():
+    for child in get_children():
+        if child is StaticBody2D or child is RigidBody2D:
+            child.queue_free()
+
+func _generate_layout():
+    var left = wall_scene.instantiate()
+    left.position = Vector2(0, 240)
+    add_child(left)
+
+    var right = wall_scene.instantiate()
+    right.position = Vector2(640, 240)
+    add_child(right)
+
+    var floor = wall_scene.instantiate()
+    floor.position = Vector2(320, 480)
+    floor.rotation = deg_to_rad(90)
+    add_child(floor)
+
+    var count = randi() % 4 + 2
+    for i in range(count):
+        var ramp = ramp_scene.instantiate()
+        ramp.position = Vector2(randf_range(50, 590), randf_range(200, 430))
+        ramp.rotation = deg_to_rad(randf_range(-45, 45))
+        add_child(ramp)

--- a/scripts/Ramp.gd
+++ b/scripts/Ramp.gd
@@ -1,0 +1,11 @@
+extends StaticBody2D
+
+# Prosta rampa - rysowana w skrypcie
+@onready var shape: RectangleShape2D = $CollisionShape2D.shape
+
+func _ready():
+    update()
+
+func _draw() -> void:
+    var rect = Rect2(-shape.size/2, shape.size)
+    draw_rect(rect, Color(0.8, 0.8, 0.8))

--- a/scripts/Wall.gd
+++ b/scripts/Wall.gd
@@ -1,0 +1,11 @@
+extends StaticBody2D
+
+# Prosta sciana
+@onready var shape: RectangleShape2D = $CollisionShape2D.shape
+
+func _ready():
+    update()
+
+func _draw() -> void:
+    var rect = Rect2(-shape.size/2, shape.size)
+    draw_rect(rect, Color(0.6, 0.6, 0.6))


### PR DESCRIPTION
## Summary
- remove binary assets from history
- reconstruct Godot project using text-only scenes and scripts
- randomize ramps and walls, spawning balls periodically
- draw simple shapes in GDScript

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d3491bcac832280dd681f9c5d7061